### PR TITLE
Fix typo in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ linear inequality constraints).
 Installation
 ------------
 Simplest way to install levmar and its dependencies is to use the
-`conda pacakge manager <https://conda.pydata.org/docs/>`_::
+`conda package manager <https://conda.pydata.org/docs/>`_::
 
    $ conda install -c bjodah levmar pytest
    $ python -m pytest --pyargs levmar  # runs the test-suite


### PR DESCRIPTION
This is actually mostly an excuse to kindly request a new release on PyPI -- the current sdist is too old to be used with Python 3.7 (one gets errors about missing members of PyThreadState when compiling); it is just a matter of rerunning `setup.py sdist` with a more recent cython.